### PR TITLE
Fix wrong link for the project homepage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/jhollingworth/bootstrap-wysihtml5
 
 bootstrap-wysihtml5-rails project integrates it with Rails 3 assets pipeline.
 
-http://github.com/Nerian/bootstrap-wysihtml5
+https://github.com/Nerian/bootstrap-wysihtml5-rails
 
 
 ## Rails > 3.1


### PR DESCRIPTION
A quick fix: the repository name was wrong and also changed the link to use HTTPS.
