### PR TITLE
Pass through all options to wysihtml5

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5.js
@@ -137,22 +137,11 @@
 		constructor: Wysihtml5,
 
     createEditor: function(options) {
-      var parserRules = defaultOptions.parserRules; 
-      var stylesheets = defaultOptions.stylesheets;
+      options = $.extend(defaultOptions, options || {});
 
-      if(options && options.parserRules) {
-        parserRules = options.parserRules;
-      }
+      options.toolbar = this.toolbar.attr('id');
 
-      if (options && options.stylesheets) {
-        stylesheets = options.stylesheets;
-      }
-
-      var editor = new wysi.Editor(this.el.attr('id'), {
-        toolbar: this.toolbar.attr('id'),
-        parserRules: parserRules,
-        stylesheets: stylesheets
-      });
+      var editor = new wysi.Editor(this.el.attr('id'), options);
 
       if(options && options.events) {
         for(var eventName in options.events) {


### PR DESCRIPTION
I was attempting to customize wysihtml5 by sending [configuration parameters](https://github.com/xing/wysihtml5/wiki/Configuration).

However, I noticed you only send through `parserRules` and `stylesheets`.

This pull request sends any arbitrary options through to wysihtml5.
