### PR TITLE
fix for the editor not being returned from constructor

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5.js
@@ -314,16 +314,16 @@
         shallowExtend: function (options) {
             var settings = $.extend({}, $.fn.wysihtml5.defaultOptions, options || {});
             var that = this;
-            methods.bypassDefaults.apply(that, [settings]);
+            return methods.bypassDefaults.apply(that, [settings]);
         },
         deepExtend: function(options) {
             var settings = $.extend(true, {}, $.fn.wysihtml5.defaultOptions, options || {});
             var that = this;
-            methods.bypassDefaults.apply(that, [settings]);
+            return methods.bypassDefaults.apply(that, [settings]);
         },
         init: function(options) {
             var that = this;
-            methods.shallowExtend.apply(that, [options]);
+            return methods.shallowExtend.apply(that, [options]);
         }
     };
 


### PR DESCRIPTION
With the 0.3.1.1 changes, a call to:

``` javascript
elem.wysihtml5()
```

would return undefined. I noticed that the init functions had been refactored and were working fine but not returning the result. Adding returns to them fixes the problem.
