### PR TITLE
dutch translation

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/locales/nl-NL.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/locales/nl-NL.js
@@ -1,5 +1,5 @@
 /**
- * German translation for bootstrap-wysihtml5
+ * Dutch translation for bootstrap-wysihtml5
  */
 (function($){
     $.fn.wysihtml5.locale["nl-NL"] = {


### PR DESCRIPTION
I noticed that there is a `fr-NL.js` translation, but that locale is wrong, there is no such thing as a dutch language in France ;-)

So I made an `nl-NL.js` translation.
