### PR TITLE
Make the bootstrap-wysihtml5/wysiwyg-color file request by the JS remote asset pipeline friendly, and general asset pipeline friendly.

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -421,7 +421,7 @@
                 "div": 1
             }
         },
-        stylesheets: ["<%= Rails.configuration.assets.prefix + '/bootstrap-wysihtml5/wysiwyg-color.css' %>"], // (path_to_project/lib/css/wysiwyg-color.css)
+        stylesheets: ["<%= Rails.configuration.action_controller.asset_host.to_s% Random.new().rand(1..3) + ActionController::Base.helpers.stylesheet_path('bootstrap-wysihtml5/wysiwyg-color') %>"], // (path_to_project/lib/css/wysiwyg-color.css)
         locale: "en"
     };
 


### PR DESCRIPTION
I host my asset pipeline on an S3 with an Amazon Cloud Front in front of it. The way the core.js.erb was set up before it wouldn't take into account the asset host being a sperate url, so it would end up with requests to the web server instead of the actually asset host for the wysiwyg-color.css file.

It now finds the url for wysiwyg-color.css file in a way that works with remotely hosted asset pipelines.

The % Random.new().rand(1..3) bit is to follow the rails behavior when you put %d in the asset pipe host it puts in a random number from 1 to 3.

``` ruby
Rails.configuration.action_controller.asset_host.to_s% Random.new().rand(1..3) + ActionController::Base.helpers.stylesheet_path('bootstrap-wysihtml5/wysiwyg-color')

```
