### PR TITLE
Fix bug when inserting image using with bootstrap-editable

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -262,7 +262,7 @@
                 if (!activeButton) {
                     self.editor.currentView.element.focus(false);
                     caretBookmark = self.editor.composer.selection.getBookmark();
-                    insertImageModal.modal('show');
+                    insertImageModal.appendTo('body').modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });


### PR DESCRIPTION
I find a little bug when using it with bootstrap-ediable: when the insert-image-button clicked the insert-image-modal was covered by the modal-backdrop layer。For details please see Demo for bootstrap-editable on http://vitalets.github.com/x-editable/demo.html
