### PR TITLE
Remove console.log (cause IE 9 breaks on this when pasing)

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
@@ -8516,8 +8516,6 @@ wysihtml5.views.View = Base.extend(
       var dataTransfer = event.dataTransfer,
           data;
 
-
-      console.log('PASTED', event);
       if (dataTransfer && browser.supportsDataTransfer()) {
         data = dataTransfer.getData("text/html") || dataTransfer.getData("text/plain");
       }
@@ -9434,10 +9432,6 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
           this.toolbar = new wysihtml5.toolbar.Toolbar(this, this.config.toolbar);
         }
       });
-      
-      try {
-        console.log("Heya! This page is using wysihtml5 for rich text editing. Check out https://github.com/xing/wysihtml5");
-      } catch(e) {}
     },
     
     isCompatible: function() {


### PR DESCRIPTION
Removed two entries of console.log since this doesn't belong in production-ready code and breaks in IE 9
