### PR TITLE
Added support for Youtube and Vimeo videos.

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -345,6 +345,7 @@
                     self.editor.currentView.element.focus();
                     self.editor.composer.commands.exec("insertVideo", { src: embedUrl, width: '398', height: '224' });
                     resetFields();
+                    return true;
                 } else if ( linkUrl.substr(0,17) == 'http://vimeo.com/' ) {
                     // Vimeo video
                     var linkParams = linkUrl.substr(17)
@@ -354,6 +355,7 @@
                     self.editor.currentView.element.focus();
                     self.editor.composer.commands.exec("insertVideo", { src: embedUrl, width: '500', height: '281' })
                     resetFields();
+                    return true;
                 } else {
                     errorSpan.show();
                     return false;


### PR DESCRIPTION
I pulled together the code for embedding youtube video from @puredistortion and added Vimeo support. I also corrected some BS3 specific events for modal windows. You're welcome to port this code to BS2 also and improve the JS code where needed.

Inspired from https://github.com/puredistortion/bootstrap-wysihtml5/commit/7e2c149dd2a3b6f416dae97d79c4d585eae7a7e9
