### PR TITLE
Use depend_on_asset for wysiwyg-color.css file

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -1,3 +1,5 @@
+//= depend_on_asset "bootstrap-wysihtml5/wysiwyg-color.css"
+
 !function($, wysi) {
     "use strict";
 

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -1,3 +1,5 @@
+//= depend_on_asset "bootstrap-wysihtml5/wysiwyg-color.css"
+
 !function($, wysi) {
     "use strict";
 


### PR DESCRIPTION
We've started using https://github.com/schneems/sprockets_better_errors and is requesting adding depend_on_asset for wysiwyg-color.css to these two files.

`//= depend_on_asset "bootstrap-wysihtml5/wysiwyg-color.css"`
