### PR TITLE
Use def input(wrapper_options) instead of def input

### DIFF
--- a/lib/bootstrap-wysihtml5-rails/simple_form/wysihtml5_input.rb
+++ b/lib/bootstrap-wysihtml5-rails/simple_form/wysihtml5_input.rb
@@ -1,5 +1,5 @@
 class Wysihtml5Input < SimpleForm::Inputs::TextInput
-  def input
+  def input(wrapper_options)
     idf = "#{lookup_model_names.join("_")}_#{reflection_or_attribute_name}"
     script = template.content_tag(:script, type: 'text/javascript') do
       "$('textarea[id=#{idf}]').wysihtml5();".html_safe


### PR DESCRIPTION
DEPRECATION WARNING: input method now accepts a `wrapper_options` argument. 

See https://github.com/plataformatec/simple_form/pull/997 for more information.