### PR TITLE
"Twitter Bootstrap" => "Bootstrap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Bootstrap](http://getbootstrap.com) is a toolkit from Twitter designed to kickstart development of webapps and sites. It includes base CSS and HTML for typography, forms, buttons, tables, grids, navigation, and more.
 
-http://twitter.github.com/bootstrap/
+http://getbootstrap.com/
 
 Bootstrap Wysihtml5 is a plugin for Bootstrap designed by James Hollingworth. It provides a stylish wysiwyg editor for Bootstrap. We use Christian Sterzl's fork.
 

--- a/bootstrap-wysihtml5-rails.gemspec
+++ b/bootstrap-wysihtml5-rails.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/bootstrap-wysihtml5-rails/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Gonzalo Rodríguez-Baltanás Díaz"]
   gem.email         = ["siotopo@gmail.com"]
-  gem.description   = %q{A wysiwyg text editor for Twitter Bootstrap}
+  gem.description   = %q{A wysiwyg text editor for Bootstrap}
   gem.homepage      = "https://github.com/Nerian/bootstrap-wysihtml5-rails"
   gem.summary       = gem.description
   gem.license       = 'MIT'


### PR DESCRIPTION
And update Bootstrap's homepage URL.

Since version 3, Bootstrap is no longer organizationally affiliated with Twitter.
See http://getbootstrap.com/about/#name and https://github.com/twbs/bootstrap/issues/9899